### PR TITLE
Auctor Labelling Cleanup

### DIFF
--- a/assets/js/block-extensions/post-excerpt.js
+++ b/assets/js/block-extensions/post-excerpt.js
@@ -49,14 +49,14 @@
                     createElement(
                         PanelBody,
                         {
-                            title: __('Link Settings', 'moiraine'),
+                            title: __('Link Settings', 'auctor'),
                             initialOpen: false,
                             className: "moiraine-excerpt-link-settings"
                         },
                         createElement(
                             ToggleControl,
                             {
-                                label: __('Link excerpt to post', 'moiraine'),
+                                label: __('Link excerpt to post', 'auctor'),
                                 checked: !!linkToPost,
                                 onChange: function() {
                                     setAttributes({ linkToPost: !linkToPost });
@@ -66,7 +66,7 @@
                         linkToPost && createElement(
                             ToggleControl,
                             {
-                                label: __('Underline link', 'moiraine'),
+                                label: __('Underline link', 'auctor'),
                                 checked: !!underlineLink,
                                 onChange: function() {
                                     setAttributes({ underlineLink: !underlineLink });
@@ -108,19 +108,19 @@
     // Register our filters
     addFilter(
         'blocks.registerBlockType',
-        'moiraine/post-excerpt-link-attributes',
+        'auctor/post-excerpt-link-attributes',
         addAttributes
     );
 
     addFilter(
         'editor.BlockEdit',
-        'moiraine/post-excerpt-link-controls',
+        'auctor/post-excerpt-link-controls',
         withInspectorControls
     );
 
     addFilter(
         'editor.BlockListBlock',
-        'moiraine/post-excerpt-link-class',
+        'auctor/post-excerpt-link-class',
         withCustomClassName
     );
 })(window.wp);

--- a/assets/js/custom-blocks.js
+++ b/assets/js/custom-blocks.js
@@ -9,7 +9,7 @@
     // Add custom attribute to post-excerpt block
     addFilter(
         'blocks.registerBlockType',
-        'thaiconomics/post-excerpt-link',
+        'auctor/post-excerpt-link',
         function(settings, name) {
             if (name !== 'core/post-excerpt') {
                 return settings;
@@ -61,14 +61,14 @@
 
     addFilter(
         'editor.BlockEdit',
-        'thaiconomics/post-excerpt-link',
+        'auctor/post-excerpt-link',
         withInspectorControls
     );
 
     // Add custom rendering for the frontend
     addFilter(
         'blocks.getSaveElement',
-        'thaiconomics/post-excerpt-link',
+        'auctor/post-excerpt-link',
         function(element, blockType, attributes) {
             if (blockType.name !== 'core/post-excerpt' || !attributes.linkToPost) {
                 return element;
@@ -83,7 +83,7 @@
     // Make sure the linkToPost attribute is available to PHP
     addFilter(
         'blocks.getSaveContent.extraProps',
-        'thaiconomics/post-excerpt-link',
+        'auctor/post-excerpt-link',
         function(extraProps, blockType, attributes) {
             if (blockType.name === 'core/post-excerpt' && attributes.linkToPost) {
                 extraProps['data-link-to-post'] = 'true';

--- a/inc/block-extensions.php
+++ b/inc/block-extensions.php
@@ -41,7 +41,7 @@ function moiraine_enqueue_block_extensions() {
         'wp.domReady(function() {
             wp.hooks.addFilter(
                 "blocks.registerBlockType",
-                "thaiconomics/post-excerpt-attributes",
+                "auctor/post-excerpt-attributes",
                 function(settings, name) {
                     if (name !== "core/post-excerpt") {
                         return settings;


### PR DESCRIPTION
This pull request updates the naming conventions for block extensions related to post excerpts in both JavaScript and PHP files. The main change is a migration from the previous namespaces (`moiraine` and `thaiconomics`) to the new namespace `auctor`, ensuring consistency across all filters and UI labels.

**Namespace migration and consistency:**

* Updated all filter identifiers in `assets/js/block-extensions/post-excerpt.js` from `moiraine` to `auctor`, including block registration, inspector controls, and class name filters.
* Changed UI labels in `assets/js/block-extensions/post-excerpt.js` from `'moiraine'` to `'auctor'` for link settings, link to post, and underline link options. [[1]](diffhunk://#diff-89fe16b5390fa4c5e0f99e909deb015b82f4174e40e3c1deecaa4437a978841fL52-R59) [[2]](diffhunk://#diff-89fe16b5390fa4c5e0f99e909deb015b82f4174e40e3c1deecaa4437a978841fL69-R69)
* Migrated filter identifiers in `assets/js/custom-blocks.js` from `thaiconomics` to `auctor` for block registration, editor controls, frontend rendering, and extra props. [[1]](diffhunk://#diff-b2a1f13904aa8c095a78d2b06a2211748ec29107167e5a4164e513241ade8af5L12-R12) [[2]](diffhunk://#diff-b2a1f13904aa8c095a78d2b06a2211748ec29107167e5a4164e513241ade8af5L64-R71) [[3]](diffhunk://#diff-b2a1f13904aa8c095a78d2b06a2211748ec29107167e5a4164e513241ade8af5L86-R86)
* Updated the filter identifier in the inline JavaScript within `inc/block-extensions.php` from `thaiconomics/post-excerpt-attributes` to `auctor/post-excerpt-attributes`.