### PR TITLE
Version 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the Auctor theme will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2025-09-17
+
+### Fixed
+- **Branding consistency**: Removed remaining Thaiconomics and Moiraine references from JavaScript files
+  - Updated `assets/js/block-extensions/post-excerpt.js`: Changed text domain and filter names from 'moiraine' to 'auctor'
+  - Updated `assets/js/custom-blocks.js`: Changed filter namespace from 'thaiconomics' to 'auctor'
+  - Updated `inc/block-extensions.php`: Changed filter namespace from 'thaiconomics' to 'auctor'
+
+### Technical Details
+- All JavaScript filter hooks now use consistent 'auctor' namespace
+- Block extension translations properly reference 'auctor' text domain
+- Completes the rebranding effort for all theme components
+
 ## [1.1.1] - 2025-09-17
 
 ### Added

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: blog, publishing, editorial, writers, magazines, newspapers, grid-layout, 
 Requires at least: 6.0
 Tested up to: 6.7.1
 Requires PHP: 7.3
-Stable tag: 1.1.0
+Stable tag: 1.1.2
 License: GNU General Public License v3.0 (or later)
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -15,6 +15,22 @@ Auctor is a modern WordPress block theme designed specifically for editors, publ
 Auctor features carefully crafted typefaces, optimized reading experiences, and specialized patterns for article layouts, making it the perfect choice for magazines, newspapers, blogs, and any publication-focused website. The theme includes 70+ block patterns, 5 style variations, and comprehensive full site editing support.
 
 == Changelog ==
+
+= 1.1.2 - 09/17/25 =
+* Fixed branding consistency by removing remaining Thaiconomics and Moiraine references from JavaScript files
+* Updated assets/js/block-extensions/post-excerpt.js to use 'auctor' text domain and filter names
+* Updated assets/js/custom-blocks.js to use 'auctor' filter namespace instead of 'thaiconomics'
+* Updated inc/block-extensions.php to use 'auctor' filter namespace
+* All JavaScript filter hooks now use consistent 'auctor' namespace
+* Completes the rebranding effort for all theme components
+
+= 1.1.1 - 09/17/25 =
+* Enhanced index template with comprehensive block patterns showcase
+* Added hero section, testimonials, feature boxes, and statistics sections
+* Created comprehensive theme showcase documentation in docs/BLOCKS-DISPLAY.md
+* Updated duotone color schemes across multiple patterns for better brand consistency
+* Transformed index template from simple blog listing to full theme demonstration
+* All pattern additions maintain responsive design principles
 
 = 1.1.0 - 09/17/25 =
 * Added comprehensive theme documentation for users and developers

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: Independent theme combining Moiraine's patterns with Thaiconomics e
 Tags: blog, portfolio, entertainment, grid-layout, one-column, two-columns, three-columns, four-columns, block-patterns, block-styles, custom-logo, custom-menu, editor-style, featured-images, full-site-editing, full-width-template, rtl-language-support, style-variations, template-editing, theme-options, translation-ready, wide-blocks
 Tested up to: 6.7.1
 Requires PHP: 7.3
-Version: 1.1.1
+Version: 1.1.2
 License: GNU General Public License v3 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: auctor


### PR DESCRIPTION
This pull request finalizes the branding transition for the Auctor theme by ensuring that all references to previous brands (Thaiconomics and Moiraine) are removed from JavaScript and PHP files. It also updates version numbers and documentation to reflect the new release. The most important changes are grouped below:

**Branding Consistency Updates:**

* Removed all remaining 'Thaiconomics' and 'Moiraine' references from JavaScript files, ensuring only 'auctor' is used for text domains and filter namespaces. (`assets/js/block-extensions/post-excerpt.js`, `assets/js/custom-blocks.js`, `inc/block-extensions.php`)
* All JavaScript filter hooks now consistently use the 'auctor' namespace, completing the rebranding effort across theme components.

**Documentation and Versioning:**

* Updated `CHANGELOG.md` and `readme.txt` to document the branding fixes and new release (1.1.2), including a detailed changelog entry. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R20) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R19-R34)
* Incremented theme version to 1.1.2 in `style.css` and `readme.txt` to reflect the new release. [[1]](diffhunk://#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7aL10-R10) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7)